### PR TITLE
Fix compatibility issues with symfony 7 in commands

### DIFF
--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -61,14 +61,14 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $driver = $this->getDriver();
 
         if ($input->isInteractive()) {
             if (!$this->askConfirmation('WARNING! Are you sure you wish to continue? (y/n)', $input, $output)) {
                 $output->writeln('<error>Maintenance cancelled!</error>');
-                return null;
+                return Command::FAILURE;
             }
         } elseif (null !== $input->getArgument('ttl')) {
             $this->ttl = $input->getArgument('ttl');
@@ -82,7 +82,7 @@ EOT
         }
 
         $output->writeln('<info>'.$driver->getMessageLock($driver->lock()).'</info>');
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -46,10 +46,10 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->confirmUnlock($input, $output)) {
-            return null;
+            return Command::FAILURE;
         }
 
         $driver = $this->container->get('lexik_maintenance.driver.factory')->getDriver();
@@ -57,7 +57,7 @@ EOT
         $unlockMessage = $driver->getMessageUnlock($driver->unlock());
 
         $output->writeln('<info>'.$unlockMessage.'</info>');
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This fix the signature of `execute()` in commands to conform to the parent class from symfony.

If you want to return 0 instead when canceling I can make the change.