### PR TITLE
fix: Compatibility with Symfony 7 (return types + deprecated constant)

### DIFF
--- a/Command/DriverLockCommand.php
+++ b/Command/DriverLockCommand.php
@@ -61,14 +61,14 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $driver = $this->getDriver();
 
         if ($input->isInteractive()) {
             if (!$this->askConfirmation('WARNING! Are you sure you wish to continue? (y/n)', $input, $output)) {
                 $output->writeln('<error>Maintenance cancelled!</error>');
-                return null;
+                return Command::FAILURE;
             }
         } elseif (null !== $input->getArgument('ttl')) {
             $this->ttl = $input->getArgument('ttl');
@@ -82,7 +82,7 @@ EOT
         }
 
         $output->writeln('<info>'.$driver->getMessageLock($driver->lock()).'</info>');
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/Command/DriverUnlockCommand.php
+++ b/Command/DriverUnlockCommand.php
@@ -46,10 +46,10 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->confirmUnlock($input, $output)) {
-            return null;
+            return Command::FAILURE;
         }
 
         $driver = $this->container->get('lexik_maintenance.driver.factory')->getDriver();
@@ -57,7 +57,7 @@ EOT
         $unlockMessage = $driver->getMessageUnlock($driver->unlock());
 
         $output->writeln('<info>'.$unlockMessage.'</info>');
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/Listener/MaintenanceListener.php
+++ b/Listener/MaintenanceListener.php
@@ -201,7 +201,7 @@ class MaintenanceListener
         // Get driver class defined in your configuration
         $driver = $this->driverFactory->getDriver();
 
-        if ($driver->decide() && HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
+        if ($driver->decide() && HttpKernelInterface::MAIN_REQUEST === $event->getRequestType()) {
             $this->handleResponse = true;
             throw new ServiceUnavailableException($this->http_exception_message);
         }


### PR DESCRIPTION
## 📝 Description

This PR updates the bundle to be compatible with Symfony 7 by fixing the following issues:

- Added proper return type (`int`) to `execute()` method in:
    - `Command\DriverLockCommand`
    - `Command\DriverUnlockCommand`  
      Symfony requires this since version 6.0.

- Replaced deprecated constant `HttpKernelInterface::MASTER_REQUEST` with `HttpKernelInterface::MAIN_REQUEST` in:
    - `Listener\MaintenanceListener`  
      `MASTER_REQUEST` was removed in Symfony 7.0 ([UPGRADE-7.0.md](https://github.com/symfony/symfony/blob/7.0/UPGRADE-7.0.md#httpkernel)).

---

## 📦 Impact

These changes allow the bundle to work properly with Symfony 7.x, avoiding type errors and deprecated constant usage.  
Backward compatibility with Symfony 6.x is preserved.

---

## 🔍 Related

Tested with **Symfony 7.3.2**