### PR TITLE
Feature: Add support to PHP 8.5.X

### DIFF
--- a/Drivers/DatabaseDriver.php
+++ b/Drivers/DatabaseDriver.php
@@ -15,7 +15,7 @@ use Lexik\Bundle\MaintenanceBundle\Drivers\Query\DsnQuery;
 class DatabaseDriver extends AbstractDriver implements DriverTtlInterface
 {
     /**
-     * @var Registry
+     * @var Registry|null
      */
     protected $doctrine;
 
@@ -38,9 +38,9 @@ class DatabaseDriver extends AbstractDriver implements DriverTtlInterface
     /**
      * Constructor
      *
-     * @param Registry $doctrine The registry
+     * @param Registry|null $doctrine The registry
      */
-    public function __construct(Registry $doctrine = null)
+    public function __construct(?Registry $doctrine = null)
     {
         $this->doctrine = $doctrine;
     }

--- a/Exception/ServiceUnavailableException.php
+++ b/Exception/ServiceUnavailableException.php
@@ -15,11 +15,11 @@ class ServiceUnavailableException extends HttpException
     /**
      * Constructor.
      *
-     * @param string     $message  The internal exception message
-     * @param \Exception $previous The previous exception
-     * @param integer    $code     The internal exception code
+     * @param string          $message  The internal exception message
+     * @param \Exception|null $previous The previous exception
+     * @param integer         $code     The internal exception code
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, ?\Exception $previous = null, $code = 0)
     {
         parent::__construct(503, $message, $previous, array(), $code);
     }


### PR DESCRIPTION
Just add the support to PHP 8.5.X to fix the depreciations :
```
PHP Deprecated:  Lexik\Bundle\MaintenanceBundle\Drivers\DatabaseDriver::__construct():
Implicitly marking parameter $doctrine as nullable is deprecated, the explicit nullable type
must be used instead in vendor/prolix/maintenance-bundle/Drivers/DatabaseDriver.php on line 43

PHP Deprecated:  Lexik\Bundle\MaintenanceBundle\Exception\ServiceUnavailableException::__construct():
Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type
must be used instead in vendor/prolix/maintenance-bundle/Exception/ServiceUnavailableException.php on line 22
```

@ravindrakhokharia 